### PR TITLE
Group Messaging Updates

### DIFF
--- a/Inbox.cpp
+++ b/Inbox.cpp
@@ -19,6 +19,7 @@
  **/
 
 #include "Inbox.h"
+#include "DriftingDateTime.h"
 
 #include <QDebug>
 
@@ -32,7 +33,15 @@ const char* SCHEMA = "CREATE TABLE IF NOT EXISTS inbox_v1 ("
                      "CREATE INDEX IF NOT EXISTS idx_inbox_v1__params_from ON"
                      "  inbox_v1(json_extract(blob, '$.params.FROM'));"
                      "CREATE INDEX IF NOT EXISTS idx_inbox_v1__params_to ON"
-                     "  inbox_v1(json_extract(blob, '$.params.TO'))";
+                     "  inbox_v1(json_extract(blob, '$.params.TO'));"
+					 "CREATE TABLE IF NOT EXISTS inbox_group_recip_v1 ("
+					 "  id INTEGER PRIMARY KEY AUTOINCREMENT, "
+					 "  msg_id INTEGER, "
+					 "  callsign VARCHAR(255), "
+					 "  FOREIGN KEY(msg_id) REFERENCES inbox_v1(id) ON DELETE CASCADE"
+					 ");"
+					 "CREATE INDEX IF NOT EXISTS idx_inbox_group_recip_v1__callsign ON"
+					 "  inbox_group_recip_v1(callsign);";
 
 Inbox::Inbox(QString path) :
     path_{ path },
@@ -309,3 +318,169 @@ QPair<int, Message> Inbox::firstUnreadFrom(QString from){
     return v.first();
 }
 
+QMap<QString, int> Inbox::getGroupMessageCounts()
+{
+	if(!isOpen()){
+		return {};
+	}
+
+	QMap<QString, int> messageCounts;
+
+	const char* sql = "SELECT count(id) as msg_count, json_extract(blob, '$.params.TO') as group_name FROM inbox_v1 "
+					  "WHERE json_extract(blob, '$.type') = 'STORE' "
+					  "AND group_name LIKE '@%' "
+					  "AND json_extract(blob, '$.params.UTC') > ? "
+					  "GROUP BY group_name";
+
+	sqlite3_stmt *stmt;
+	int rc = sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr);
+	if(rc != SQLITE_OK){
+		return messageCounts;
+	}
+
+	// Set a floor or 48 hours for group message retrieval
+	// TODO: date formatting with the "yyyy-MM-dd HH:mm:ss" string happens elsewhere as well, centralize
+	// TODO: possibly make the date floor configurable
+	auto d8 = DriftingDateTime::currentDateTimeUtc().addDays(-2).toString("yyyy-MM-dd HH:mm:ss").toLocal8Bit();
+
+	rc = sqlite3_bind_text(stmt, 1, d8.data(), -1, nullptr);
+
+	//qDebug() << "exec " << sqlite3_expanded_sql(stmt);
+
+	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+		Message m;
+
+		int count = sqlite3_column_int(stmt, 0);
+		auto group = sqlite3_column_text(stmt, 1);
+
+		messageCounts.insert(QString::fromLocal8Bit(reinterpret_cast<const char *>(group)), count);
+	}
+
+	rc = sqlite3_finalize(stmt);
+
+	return messageCounts;
+}
+
+bool Inbox::markGroupMsgDeliveredForCallsign(int msgId, const QString &callsign)
+{
+	if(!isOpen()){
+		return false;
+	}
+
+	const char* sql = "SELECT count(id) as msg_count FROM inbox_group_recip_v1 WHERE msg_id = ? AND callsign = ? LIMIT 1;";
+
+	sqlite3_stmt *exists_stmt;
+	int rc = sqlite3_prepare_v2(db_, sql, -1, &exists_stmt, nullptr);
+	if(rc != SQLITE_OK){
+		return false;
+	}
+
+	auto cs8 = callsign.toLocal8Bit();
+
+	rc = sqlite3_bind_int(exists_stmt, 1, msgId);
+	rc = sqlite3_bind_text(exists_stmt, 2, cs8.data(), -1, nullptr);
+
+	bool recordExists = false;
+	rc = sqlite3_step(exists_stmt);
+	int count = sqlite3_column_int(exists_stmt, 0);
+	recordExists = (count > 0);
+
+	rc = sqlite3_finalize(exists_stmt);
+
+	if(!recordExists)
+	{
+		sql = "INSERT INTO inbox_group_recip_v1 (msg_id, callsign) VALUES (?,?);";
+
+		sqlite3_stmt *insert_stmt;
+		rc = sqlite3_prepare_v2(db_, sql, -1, &insert_stmt, nullptr);
+		if (rc != SQLITE_OK)
+		{
+			return false;
+		}
+
+		rc = sqlite3_bind_int(insert_stmt, 1, msgId);
+		rc = sqlite3_bind_text(insert_stmt, 2, cs8.data(), -1, nullptr);
+
+		rc = sqlite3_step(insert_stmt);
+
+		rc = sqlite3_finalize(insert_stmt);
+		if (rc != SQLITE_OK)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+int Inbox::getNextGroupMessageIdForCallsign(const QString &group_name, const QString &callsign){
+	if(!isOpen()){
+		return -1;
+	}
+
+	const char* sql = "SELECT inbox_v1.id, inbox_v1.blob FROM inbox_v1 "
+					  "LEFT JOIN inbox_group_recip_v1 ON (inbox_group_recip_v1.msg_id=inbox_v1.id AND inbox_group_recip_v1.callsign = ?) "
+					  "WHERE json_extract(blob, '$.type') = 'STORE' "
+					  "AND json_extract(blob, '$.params.TO') LIKE ? "
+					  "AND json_extract(blob, '$.params.UTC') > ? "
+					  "AND inbox_group_recip_v1.id IS NULL "
+					  "ORDER BY inbox_v1.id ASC "
+					  "LIMIT ? OFFSET ?;";
+
+	sqlite3_stmt *stmt;
+	int rc = sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr);
+	if(rc != SQLITE_OK){
+		return -1;
+	}
+
+	auto c8 = callsign.toLocal8Bit();
+	auto g8 = group_name.toLocal8Bit();
+
+	// Set a floor or 48 hours for group message retrieval
+	// TODO: date formatting with the "yyyy-MM-dd HH:mm:ss" string happens elsewhere as well, centralize
+	// TODO: possibly make the date floor configurable
+	auto d8 = DriftingDateTime::currentDateTimeUtc().addDays(-2).toString("yyyy-MM-dd HH:mm:ss").toLocal8Bit();
+
+	rc = sqlite3_bind_text(stmt, 1, c8.data(), -1, nullptr);
+	rc = sqlite3_bind_text(stmt, 2, g8.data(), -1, nullptr);
+	rc = sqlite3_bind_text(stmt, 3, d8.data(), -1, nullptr);
+	rc = sqlite3_bind_int(stmt, 4, 10);
+	rc = sqlite3_bind_int(stmt, 5, 0);
+
+	//qDebug() << "exec " << sqlite3_expanded_sql(stmt);
+
+	int next_id = -1;
+	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+		Message m;
+
+		int i = sqlite3_column_int(stmt, 0);
+
+		auto msg = QByteArray((const char*)sqlite3_column_text(stmt, 1), sqlite3_column_bytes(stmt, 1));
+
+		QJsonParseError e;
+		QJsonDocument d = QJsonDocument::fromJson(msg, &e);
+		if(e.error != QJsonParseError::NoError){
+			continue;
+		}
+
+		if(!d.isObject()){
+			continue;
+		}
+
+		m.read(d.object());
+
+		auto params = m.params();
+		auto text = params.value("TEXT").toString().trimmed();
+		if(!text.isEmpty()){
+			next_id = i;
+			break;
+		}
+	}
+
+	rc = sqlite3_finalize(stmt);
+	if(rc != SQLITE_OK){
+		return -1;
+	}
+
+	return next_id;
+}

--- a/Inbox.h
+++ b/Inbox.h
@@ -37,6 +37,10 @@ public:
     int countUnreadFrom(QString from);
     QPair<int, Message> firstUnreadFrom(QString from);
 
+	QMap<QString, int> getGroupMessageCounts();
+	int getNextGroupMessageIdForCallsign(const QString &group_name, const QString &callsign);
+	bool markGroupMsgDeliveredForCallsign(int msgId, const QString &callsign);
+
 signals:
 
 public slots:

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -144,7 +144,7 @@ public slots:
   void clearBandActivity();
   void clearRXActivity();
   void clearCallActivity();
-  void createGroupCallsignTableRows(QTableWidget *table, const QString &selectedCall);
+  void createGroupCallsignTableRows(QTableWidget *table, const QString &selectedCall, bool &showIconColumn);
   void displayTextForFreq(QString text, int freq, QDateTime date, bool isTx, bool isNewLine, bool isLast);
   void writeNoticeTextToUI(QDateTime date, QString text);
   int writeMessageTextToUI(QDateTime date, QString text, int freq, bool isTx, int block=-1);
@@ -158,6 +158,7 @@ public slots:
   void resetMessageUI();
   void restoreMessage();
   void initializeDummyData();
+  void initializeGroupMessageDummyData();
   bool ensureCallsignSet(bool alert=true);
   bool ensureKeyNotStuck(QString const& text);
   bool ensureNotIdle();
@@ -1045,6 +1046,9 @@ private:
   int addCommandToMyInbox(CommandDetail d);
   int addCommandToStorage(QString type, CommandDetail d);
   int getNextMessageIdForCallsign(QString callsign);
+  int getNextGroupMessageIdForCallsign(QString group_name, QString callsign);
+  bool markGroupMsgDeliveredForCallsign(int msgId, const QString &callsign);
+  bool markMsgDelivered(int mid, Message &msg);
   QStringList parseRelayPathCallsigns(QString from, QString text);
   void processSpots();
   void processTxQueue();


### PR DESCRIPTION
These changes enable messaging for groups. For the most part, changes are implementations of the the TODO comments regarding group messaging.

Adds support for: MSG TO:@GROUPNAME - Stores message in group inbox

@GROUPNAME QUERY MSGS - If no messages directed to requesting callsign are present, will send ID of next available group message, if available

@GROUPNAME MSG TO:[CALLSIGN] - Was previously disabled, has been enabled

Enables inbox functionality for groups in the callsign list

